### PR TITLE
Add JWT authentication via Authentik

### DIFF
--- a/AuthentikTestAPI/Controllers/SecureController.cs
+++ b/AuthentikTestAPI/Controllers/SecureController.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Net.Http.Headers;
+
+namespace AuthentikTestAPI.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class SecureController : ControllerBase
+    {
+        // Endpoint accessible to any authenticated user
+        [Authorize]
+        [HttpGet("user")]
+        public IActionResult GetUser()
+        {
+            return Ok(new { message = "Hello authenticated user" });
+        }
+
+        // Endpoint restricted to users in the "admin" role
+        [Authorize(Roles = "admin")]
+        [HttpGet("admin")]
+        public IActionResult GetAdmin()
+        {
+            return Ok(new { message = "Hello admin" });
+        }
+
+        // Optional example fetching roles/groups from the /userinfo endpoint
+        [Authorize]
+        [HttpGet("userinfo")]
+        public async Task<IActionResult> GetUserInfo()
+        {
+            var accessToken = await HttpContext.GetTokenAsync("access_token");
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                return Unauthorized();
+            }
+
+            using var http = new HttpClient();
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            var res = await http.GetAsync("https://auth.hyperc.tr/application/o/userinfo/");
+            if (!res.IsSuccessStatusCode)
+            {
+                return StatusCode((int)res.StatusCode);
+            }
+
+            var json = await res.Content.ReadAsStringAsync();
+            return Content(json, "application/json");
+        }
+    }
+}

--- a/AuthentikTestAPI/Program.cs
+++ b/AuthentikTestAPI/Program.cs
@@ -14,6 +14,39 @@ namespace AuthentikTestAPI
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();
 
+            builder.Services
+                .AddAuthentication(Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerDefaults.AuthenticationScheme)
+                .AddJwtBearer(options =>
+                {
+                    // Discovery will pull issuer, signing keys and token endpoints from
+                    // https://auth.hyperc.tr/.well-known/openid-configuration
+                    // Access tokens must be signed JWTs (JWS). Encrypted JWE tokens will fail to validate.
+                    options.Authority = "https://auth.hyperc.tr";
+                    options.TokenValidationParameters = new Microsoft.IdentityModel.Tokens.TokenValidationParameters
+                    {
+                        // Validate the JWT issuer and audience
+                        ValidateIssuer = true,
+                        ValidateAudience = true,
+                        ValidAudience = "b2fS6rmY8JzD80iVplmaBq6ylM6xzKi73nEh9TVd",
+                        ValidateLifetime = true,
+                        ValidateIssuerSigningKey = true
+                    };
+
+                    // Custom error response for unauthorized requests
+                    options.Events = new Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents
+                    {
+                        OnChallenge = context =>
+                        {
+                            context.HandleResponse();
+                            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                            context.Response.ContentType = "application/json";
+                            return context.Response.WriteAsync("{\"error\":\"Unauthorized\"}");
+                        }
+                    };
+                });
+
+            builder.Services.AddAuthorization();
+
             var app = builder.Build();
 
             // Configure the HTTP request pipeline.
@@ -24,6 +57,9 @@ namespace AuthentikTestAPI
             }
 
             app.UseHttpsRedirection();
+
+            // Process authentication/authorization for incoming requests
+            app.UseAuthentication();
 
             app.UseAuthorization();
 


### PR DESCRIPTION
## Summary
- configure JWT Bearer authentication using Authentik's discovery document
- add protected endpoints for authenticated users and admin role
- example endpoint shows how to retrieve user info for roles/groups
- return custom 401 JSON response on unauthorized requests

## Testing
- `dotnet build AuthentikTestAPI.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68440bea9fe08321b6362d89c87f2832